### PR TITLE
Fix SAM.gov API authentication by passing api_key parameter

### DIFF
--- a/src/crawler/samgov_crawler.py
+++ b/src/crawler/samgov_crawler.py
@@ -99,7 +99,8 @@ class SAMGovCrawler(BaseCrawler):
                     "keyword": keyword,
                     "postedFrom": (datetime.now() - timedelta(days=30)).strftime("%m/%d/%Y"),
                     "postedTo": datetime.now().strftime("%m/%d/%Y"),
-                    "limit": 100
+                    "limit": 100,
+                    "api_key": settings.SAMGOV_API_KEY,
                 }
 
                 # API 호출


### PR DESCRIPTION
## Summary
- include the SAM.gov API key as the `api_key` query parameter when invoking the opportunities search endpoint to satisfy the API's authentication requirement

## Testing
- pytest test_manager_logging.py

------
https://chatgpt.com/codex/tasks/task_b_68d23a0dadd08328994ff4a0bf0ec016