### PR TITLE
Add Copilot Studio OpenAPI spec with bid filters

### DIFF
--- a/docs/seegene_bid_mcp_openapi.json
+++ b/docs/seegene_bid_mcp_openapi.json
@@ -1,0 +1,2917 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Seegene Bid Information MCP Server",
+    "description": "씨젠을 위한 글로벌 입찰 정보 수집 및 분석 시스템",
+    "version": "2.0.0"
+  },
+  "paths": {
+    "/jsonrpc": {
+      "get": {
+        "summary": "Mcp Alternative Paths",
+        "description": "다른 MCP 경로들에 대한 안내",
+        "operationId": "mcp_alternative_paths_jsonrpc_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "Mcp Options",
+        "description": "CORS preflight 요청 처리",
+        "operationId": "mcp_options_jsonrpc_options",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/mcp": {
+      "get": {
+        "summary": "Mcp Alternative Paths",
+        "description": "다른 MCP 경로들에 대한 안내",
+        "operationId": "mcp_alternative_paths_v1_mcp_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "Mcp Options",
+        "description": "CORS preflight 요청 처리",
+        "operationId": "mcp_options_v1_mcp_options",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp": {
+      "get": {
+        "summary": "Mcp Alternative Paths",
+        "description": "다른 MCP 경로들에 대한 안내",
+        "operationId": "mcp_alternative_paths_api_mcp_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "Mcp Options",
+        "description": "CORS preflight 요청 처리",
+        "operationId": "mcp_options_api_mcp_options",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp/": {
+      "options": {
+        "summary": "Mcp Options",
+        "description": "CORS preflight 요청 처리",
+        "operationId": "mcp_options_mcp__options",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp": {
+      "options": {
+        "summary": "Mcp Options",
+        "description": "CORS preflight 요청 처리",
+        "operationId": "mcp_options_mcp_options",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "summary": "Root",
+        "description": "루트 엔드포인트",
+        "operationId": "root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Health Check",
+        "description": "헬스 체크",
+        "operationId": "health_check_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/compliance/sites": {
+      "get": {
+        "summary": "Get Site Compliance Catalog",
+        "description": "지원 대상 조달 사이트의 크롤링 및 법적 유의사항 목록을 반환합니다.",
+        "operationId": "get_site_compliance_catalog_compliance_sites_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteComplianceListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/compliance/sites/{slug}": {
+      "get": {
+        "summary": "Get Site Compliance Detail",
+        "description": "특정 조달 사이트의 크롤링 가이드라인을 조회합니다.",
+        "operationId": "get_site_compliance_detail_compliance_sites__slug__get",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteComplianceResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/crawler-status": {
+      "get": {
+        "summary": "Crawler Status Endpoint",
+        "description": "크롤러 상태 확인 엔드포인트",
+        "operationId": "crawler_status_endpoint_crawler_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/crawl/{site_name}": {
+      "post": {
+        "summary": "Run Single Crawler",
+        "description": "특정 사이트에서 크롤링 실행",
+        "operationId": "run_single_crawler_crawl__site_name__post",
+        "parameters": [
+          {
+            "name": "site_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Site Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CrawlerRequest",
+                "default": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CrawlerExecutionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/crawl-all": {
+      "post": {
+        "summary": "Run All Crawlers Endpoint",
+        "description": "모든 사이트에서 크롤링 실행",
+        "operationId": "run_all_crawlers_endpoint_crawl_all_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CrawlerRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AllCrawlerExecutionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/crawl-results": {
+      "get": {
+        "summary": "Get Crawler Results",
+        "description": "최근 크롤링 결과 조회",
+        "operationId": "get_crawler_results_crawl_results_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CrawlerResultsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/crawl-results/{site_name}": {
+      "get": {
+        "summary": "Get Site Crawler Results",
+        "description": "특정 사이트 크롤링 결과 조회",
+        "operationId": "get_site_crawler_results_crawl_results__site_name__get",
+        "parameters": [
+          {
+            "name": "site_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Site Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteCrawlerResultResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/scheduled-jobs": {
+      "get": {
+        "summary": "Get Scheduled Jobs Endpoint",
+        "description": "예약된 크롤링 작업 목록 조회",
+        "operationId": "get_scheduled_jobs_endpoint_scheduled_jobs_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduledJobsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/schedule-crawler": {
+      "post": {
+        "summary": "Add Crawler Schedule Endpoint",
+        "description": "크롤러 스케줄 추가",
+        "operationId": "add_crawler_schedule_endpoint_schedule_crawler_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScheduleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduleResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/schedule-crawler/{job_id}": {
+      "delete": {
+        "summary": "Remove Crawler Schedule Endpoint",
+        "description": "크롤러 스케줄 제거",
+        "operationId": "remove_crawler_schedule_endpoint_schedule_crawler__job_id__delete",
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Job Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduleResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/advanced": {
+      "post": {
+        "summary": "Advanced Search Endpoint",
+        "description": "고급 입찰 검색",
+        "operationId": "advanced_search_endpoint_search_advanced_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdvancedBidSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdvancedSearchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/keyword-suggestions": {
+      "get": {
+        "summary": "Get Keyword Suggestions",
+        "description": "키워드 제안",
+        "operationId": "get_keyword_suggestions_search_keyword_suggestions_get",
+        "parameters": [
+          {
+            "name": "keywords",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Keywords"
+            }
+          },
+          {
+            "name": "max_suggestions",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "title": "Max Suggestions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KeywordSuggestionsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/expanded": {
+      "post": {
+        "summary": "Search With Keyword Expansion",
+        "description": "키워드 확장을 포함한 간단한 검색",
+        "operationId": "search_with_keyword_expansion_search_expanded_post",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "title": "Limit"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_search_with_keyword_expansion_search_expanded_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdvancedSearchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/filters-help": {
+      "get": {
+        "summary": "Get Filters Help",
+        "description": "고급 필터링 도움말",
+        "operationId": "get_filters_help_search_filters_help_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bids": {
+      "get": {
+        "summary": "Get All Bids",
+        "description": "저장된 입찰 정보 목록 조회",
+        "operationId": "get_all_bids_bids_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Maximum number of bids to return per page."
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            },
+            "description": "Number of bids to skip before starting to collect the result set."
+          },
+          {
+            "name": "site",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Site"
+            },
+            "description": "Filter bids by the originating procurement site name."
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Country"
+            },
+            "description": "Filter bids by the ISO country code of the opportunity."
+          },
+          {
+            "name": "min_relevance",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "title": "Min Relevance",
+              "format": "float"
+            },
+            "description": "Return only bids with a relevance score greater than or equal to this value."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BidListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bids/{bid_id}": {
+      "get": {
+        "summary": "Get Bid By Id",
+        "description": "특정 입찰 정보 상세 조회",
+        "operationId": "get_bid_by_id_bids__bid_id__get",
+        "parameters": [
+          {
+            "name": "bid_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Bid Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BidDetailResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bids/search": {
+      "get": {
+        "summary": "Search Bids Endpoint",
+        "description": "입찰 정보 검색",
+        "operationId": "search_bids_endpoint_bids_search_get",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Q"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "site",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Site"
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Country"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BidSearchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bids/stats": {
+      "get": {
+        "summary": "Get Bid Statistics",
+        "description": "입찰 정보 통계",
+        "operationId": "get_bid_statistics_bids_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BidStatisticsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/test/db": {
+      "get": {
+        "summary": "Test Database",
+        "description": "데이터베이스 연결 테스트",
+        "operationId": "test_database_test_db_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/reset-database": {
+      "post": {
+        "summary": "Reset Database",
+        "description": "데이터베이스 초기화 (모든 데이터 삭제)",
+        "operationId": "reset_database_admin_reset_database_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/clean-dummy-data": {
+      "post": {
+        "summary": "Clean Dummy Data",
+        "description": "더미 데이터만 삭제",
+        "operationId": "clean_dummy_data_admin_clean_dummy_data_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/database-info": {
+      "get": {
+        "summary": "Get Database Info",
+        "description": "데이터베이스 정보 조회",
+        "operationId": "get_database_info_admin_database_info_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp-status": {
+      "get": {
+        "summary": "Mcp Status",
+        "description": "MCP 서버 상태 확인",
+        "operationId": "mcp_status_mcp_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp/tools": {
+      "get": {
+        "summary": "List Mcp Tools Endpoint",
+        "description": "HTTP endpoint that exposes available MCP tools for Smithery UI.",
+        "operationId": "list_mcp_tools_endpoint_mcp_tools_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response List Mcp Tools Endpoint Mcp Tools Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp/tools/{tool_name}": {
+      "get": {
+        "summary": "Get Mcp Tool Details",
+        "description": "HTTP endpoint to fetch a single MCP tool definition.",
+        "operationId": "get_mcp_tool_details_mcp_tools__tool_name__get",
+        "parameters": [
+          {
+            "name": "tool_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tool Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Mcp Tool Details Mcp Tools  Tool Name  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AdvancedBidSearchRequest": {
+        "properties": {
+          "query": {
+            "$ref": "#/components/schemas/AdvancedSearchQuery",
+            "description": "검색 쿼리"
+          },
+          "expansion": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/KeywordExpansion"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "키워드 확장 설정"
+          },
+          "custom_filters": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/SearchFilter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custom Filters",
+            "description": "커스텀 필터"
+          },
+          "include_metadata": {
+            "type": "boolean",
+            "title": "Include Metadata",
+            "description": "메타데이터 포함 여부",
+            "default": false
+          },
+          "explain_relevance": {
+            "type": "boolean",
+            "title": "Explain Relevance",
+            "description": "관련성 점수 설명 포함 여부",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "query"
+        ],
+        "title": "AdvancedBidSearchRequest",
+        "description": "고급 입찰 검색 요청"
+      },
+      "AdvancedSearchQuery": {
+        "properties": {
+          "keyword_groups": {
+            "items": {
+              "$ref": "#/components/schemas/KeywordGroup"
+            },
+            "type": "array",
+            "title": "Keyword Groups",
+            "description": "키워드 그룹 목록",
+            "default": []
+          },
+          "exclude_keywords": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exclude Keywords",
+            "description": "제외할 키워드"
+          },
+          "exact_phrases": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exact Phrases",
+            "description": "정확한 구문 검색"
+          },
+          "countries": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Countries",
+            "description": "국가 필터 (KR, US, CN 등)"
+          },
+          "sites": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sites",
+            "description": "사이트 필터 (G2B, SAM.gov 등)"
+          },
+          "organizations": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Organizations",
+            "description": "발주기관 필터"
+          },
+          "announcement_date_range": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DateRange"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "공고일 범위"
+          },
+          "deadline_date_range": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DateRange"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "마감일 범위"
+          },
+          "price_range": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PriceRange"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "가격 범위"
+          },
+          "min_relevance_score": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 10.0,
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Relevance Score",
+            "description": "최소 관련성 점수 (0-10)"
+          },
+          "relevance_level": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RelevanceLevel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "관련성 레벨"
+          },
+          "urgency_levels": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/UrgencyLevel"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Urgency Levels",
+            "description": "긴급도 레벨 필터"
+          },
+          "sort_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort By",
+            "description": "정렬 기준 (relevance, date, price, urgency)",
+            "default": "relevance"
+          },
+          "sort_order": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort Order",
+            "description": "정렬 순서 (asc, desc)",
+            "default": "desc"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 1000.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limit",
+            "description": "결과 개수 제한",
+            "default": 50
+          },
+          "offset": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Offset",
+            "description": "결과 오프셋",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "AdvancedSearchQuery",
+        "description": "고급 검색 쿼리"
+      },
+      "AdvancedSearchResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "검색 성공 여부"
+          },
+          "total_found": {
+            "type": "integer",
+            "title": "Total Found",
+            "description": "총 발견 건수"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/SearchResult"
+            },
+            "type": "array",
+            "title": "Results",
+            "description": "검색 결과"
+          },
+          "search_time": {
+            "type": "number",
+            "title": "Search Time",
+            "description": "검색 소요 시간(초)"
+          },
+          "query_summary": {
+            "type": "string",
+            "title": "Query Summary",
+            "description": "검색 쿼리 요약"
+          },
+          "filters_applied": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Filters Applied",
+            "description": "적용된 필터 목록"
+          },
+          "aggregations": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aggregations",
+            "description": "집계 정보 (국가별, 사이트별, 긴급도별 등)"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset",
+            "description": "오프셋"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit",
+            "description": "제한"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More",
+            "description": "더 많은 결과 존재 여부"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "total_found",
+          "results",
+          "search_time",
+          "query_summary",
+          "filters_applied",
+          "offset",
+          "limit",
+          "has_more"
+        ],
+        "title": "AdvancedSearchResponse",
+        "description": "고급 검색 응답"
+      },
+      "AllCrawlerExecutionResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "요청 성공 여부"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "응답 메시지"
+          },
+          "result": {
+            "$ref": "#/components/schemas/AllCrawlerResult",
+            "description": "전체 크롤링 결과"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message",
+          "result"
+        ],
+        "title": "AllCrawlerExecutionResponse",
+        "description": "전체 크롤러 실행 응답 모델"
+      },
+      "AllCrawlerResult": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "전체 크롤링 성공 여부"
+          },
+          "total_crawlers": {
+            "type": "integer",
+            "title": "Total Crawlers",
+            "description": "총 크롤러 수"
+          },
+          "successful_crawlers": {
+            "type": "integer",
+            "title": "Successful Crawlers",
+            "description": "성공한 크롤러 수"
+          },
+          "total_found": {
+            "type": "integer",
+            "title": "Total Found",
+            "description": "전체 발견된 입찰 정보 수"
+          },
+          "results": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CrawlerResult"
+            },
+            "type": "object",
+            "title": "Results",
+            "description": "사이트별 결과"
+          },
+          "run_time": {
+            "type": "string",
+            "title": "Run Time",
+            "description": "실행 시간 ISO 포맷"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "total_crawlers",
+          "successful_crawlers",
+          "total_found",
+          "results",
+          "run_time"
+        ],
+        "title": "AllCrawlerResult",
+        "description": "전체 크롤링 결과 모델"
+      },
+      "BidDetailItem": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id",
+            "description": "입찰 정보 ID"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title",
+            "description": "입찰 제목"
+          },
+          "organization": {
+            "type": "string",
+            "title": "Organization",
+            "description": "발주 기관"
+          },
+          "bid_number": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bid Number",
+            "description": "입찰 번호"
+          },
+          "announcement_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Announcement Date",
+            "description": "공고일"
+          },
+          "deadline_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deadline Date",
+            "description": "마감일"
+          },
+          "estimated_price": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Estimated Price",
+            "description": "추정 가격"
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency",
+            "description": "통화"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url",
+            "description": "원본 URL"
+          },
+          "source_site": {
+            "type": "string",
+            "title": "Source Site",
+            "description": "출처 사이트"
+          },
+          "country": {
+            "type": "string",
+            "title": "Country",
+            "description": "국가 코드"
+          },
+          "relevance_score": {
+            "type": "number",
+            "title": "Relevance Score",
+            "description": "관련성 점수"
+          },
+          "urgency_level": {
+            "type": "string",
+            "title": "Urgency Level",
+            "description": "긴급도"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "description": "상태"
+          },
+          "keywords": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Keywords",
+            "description": "매칭된 키워드"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At",
+            "description": "생성일시"
+          },
+          "extra_data": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extra Data",
+            "description": "추가 데이터"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At",
+            "description": "수정일시"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "organization",
+          "source_site",
+          "country",
+          "relevance_score",
+          "urgency_level",
+          "status"
+        ],
+        "title": "BidDetailItem",
+        "description": "입찰 정보 상세 아이템"
+      },
+      "BidDetailResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "성공 여부"
+          },
+          "data": {
+            "$ref": "#/components/schemas/BidDetailItem",
+            "description": "입찰 상세 정보"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "data"
+        ],
+        "title": "BidDetailResponse",
+        "description": "입찰 상세 응답"
+      },
+      "BidItem": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id",
+            "description": "입찰 정보 ID"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title",
+            "description": "입찰 제목"
+          },
+          "organization": {
+            "type": "string",
+            "title": "Organization",
+            "description": "발주 기관"
+          },
+          "bid_number": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bid Number",
+            "description": "입찰 번호"
+          },
+          "announcement_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Announcement Date",
+            "description": "공고일"
+          },
+          "deadline_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deadline Date",
+            "description": "마감일"
+          },
+          "estimated_price": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Estimated Price",
+            "description": "추정 가격"
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency",
+            "description": "통화"
+          },
+          "source_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Url",
+            "description": "원본 URL"
+          },
+          "source_site": {
+            "type": "string",
+            "title": "Source Site",
+            "description": "출처 사이트"
+          },
+          "country": {
+            "type": "string",
+            "title": "Country",
+            "description": "국가 코드"
+          },
+          "relevance_score": {
+            "type": "number",
+            "title": "Relevance Score",
+            "description": "관련성 점수"
+          },
+          "urgency_level": {
+            "type": "string",
+            "title": "Urgency Level",
+            "description": "긴급도"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "description": "상태"
+          },
+          "keywords": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Keywords",
+            "description": "매칭된 키워드"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At",
+            "description": "생성일시"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "organization",
+          "source_site",
+          "country",
+          "relevance_score",
+          "urgency_level",
+          "status"
+        ],
+        "title": "BidItem",
+        "description": "입찰 정보 아이템"
+      },
+      "BidListResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "성공 여부"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/BidItem"
+            },
+            "type": "array",
+            "title": "Data",
+            "description": "입찰 정보 목록"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationInfo"
+          },
+          "filters": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filters",
+            "description": "적용된 필터"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "data",
+          "pagination"
+        ],
+        "title": "BidListResponse",
+        "description": "입찰 목록 응답"
+      },
+      "BidSearchResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "성공 여부"
+          },
+          "query": {
+            "type": "string",
+            "title": "Query",
+            "description": "검색어"
+          },
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Keywords",
+            "description": "파싱된 키워드"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/BidItem"
+            },
+            "type": "array",
+            "title": "Data",
+            "description": "검색 결과"
+          },
+          "pagination": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Pagination",
+            "description": "페이지네이션 정보"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "query",
+          "keywords",
+          "data",
+          "pagination"
+        ],
+        "title": "BidSearchResponse",
+        "description": "입찰 검색 응답"
+      },
+      "BidStatisticsResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "성공 여부"
+          },
+          "statistics": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Statistics",
+            "description": "통계 정보"
+          },
+          "timestamp": {
+            "type": "string",
+            "title": "Timestamp",
+            "description": "조회 시점"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "statistics",
+          "timestamp"
+        ],
+        "title": "BidStatisticsResponse",
+        "description": "입찰 통계 응답"
+      },
+      "Body_search_with_keyword_expansion_search_expanded_post": {
+        "properties": {
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Keywords"
+          },
+          "expansion_config": {
+            "$ref": "#/components/schemas/KeywordExpansion"
+          },
+          "countries": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Countries"
+          }
+        },
+        "type": "object",
+        "required": [
+          "keywords"
+        ],
+        "title": "Body_search_with_keyword_expansion_search_expanded_post"
+      },
+      "CrawlerExecutionResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "요청 성공 여부"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "응답 메시지"
+          },
+          "result": {
+            "$ref": "#/components/schemas/CrawlerResult",
+            "description": "크롤링 결과"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message",
+          "result"
+        ],
+        "title": "CrawlerExecutionResponse",
+        "description": "크롤러 실행 응답 모델"
+      },
+      "CrawlerRequest": {
+        "properties": {
+          "keywords": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Keywords",
+            "description": "검색할 키워드 목록. 기본값은 설정된 씨젠 키워드 사용"
+          }
+        },
+        "type": "object",
+        "title": "CrawlerRequest",
+        "description": "크롤링 요청 모델"
+      },
+      "CrawlerResult": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "크롤링 성공 여부"
+          },
+          "site": {
+            "type": "string",
+            "title": "Site",
+            "description": "크롤링한 사이트명"
+          },
+          "total_found": {
+            "type": "integer",
+            "title": "Total Found",
+            "description": "발견된 입찰 정보 수"
+          },
+          "execution_time": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Execution Time",
+            "description": "실행 시간(초)",
+            "default": 0.0
+          },
+          "login_success": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Login Success",
+            "description": "로그인 성공 여부",
+            "default": false
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error",
+            "description": "오류 메시지"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "site",
+          "total_found"
+        ],
+        "title": "CrawlerResult",
+        "description": "크롤링 결과 모델"
+      },
+      "CrawlerResultsResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "요청 성공 여부"
+          },
+          "last_run_results": {
+            "additionalProperties": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "object",
+            "title": "Last Run Results",
+            "description": "최근 실행 결과"
+          },
+          "timestamp": {
+            "type": "string",
+            "title": "Timestamp",
+            "description": "조회 시간 ISO 포맷"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "last_run_results",
+          "timestamp"
+        ],
+        "title": "CrawlerResultsResponse",
+        "description": "크롤링 결과 조회 응답"
+      },
+      "DateRange": {
+        "properties": {
+          "start_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Date",
+            "description": "시작일"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Date",
+            "description": "종료일"
+          }
+        },
+        "type": "object",
+        "title": "DateRange",
+        "description": "날짜 범위 모델"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "KeywordExpansion": {
+        "properties": {
+          "enable_synonyms": {
+            "type": "boolean",
+            "title": "Enable Synonyms",
+            "description": "동의어 확장 활성화",
+            "default": true
+          },
+          "enable_related_terms": {
+            "type": "boolean",
+            "title": "Enable Related Terms",
+            "description": "관련 용어 확장 활성화",
+            "default": true
+          },
+          "enable_translations": {
+            "type": "boolean",
+            "title": "Enable Translations",
+            "description": "다국어 번역 확장 활성화",
+            "default": true
+          },
+          "enable_abbreviations": {
+            "type": "boolean",
+            "title": "Enable Abbreviations",
+            "description": "약어 확장 활성화",
+            "default": true
+          },
+          "max_expansions_per_keyword": {
+            "type": "integer",
+            "maximum": 20.0,
+            "minimum": 1.0,
+            "title": "Max Expansions Per Keyword",
+            "description": "키워드당 최대 확장 수",
+            "default": 5
+          }
+        },
+        "type": "object",
+        "title": "KeywordExpansion",
+        "description": "키워드 확장 설정"
+      },
+      "KeywordGroup": {
+        "properties": {
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Keywords",
+            "description": "키워드 목록"
+          },
+          "operator": {
+            "$ref": "#/components/schemas/SearchOperator",
+            "description": "그룹 내 연산자",
+            "default": "or"
+          },
+          "weight": {
+            "type": "number",
+            "maximum": 5.0,
+            "minimum": 0.1,
+            "title": "Weight",
+            "description": "가중치 (0.1-5.0)",
+            "default": 1.0
+          }
+        },
+        "type": "object",
+        "required": [
+          "keywords"
+        ],
+        "title": "KeywordGroup",
+        "description": "키워드 그룹"
+      },
+      "KeywordSuggestion": {
+        "properties": {
+          "keyword": {
+            "type": "string",
+            "title": "Keyword",
+            "description": "제안 키워드"
+          },
+          "frequency": {
+            "type": "integer",
+            "title": "Frequency",
+            "description": "등장 빈도"
+          },
+          "relevance": {
+            "type": "number",
+            "title": "Relevance",
+            "description": "관련도"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "description": "제안 출처 (synonym, related, translation, abbreviation)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "keyword",
+          "frequency",
+          "relevance",
+          "source"
+        ],
+        "title": "KeywordSuggestion",
+        "description": "키워드 제안"
+      },
+      "KeywordSuggestionsResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "요청 성공 여부"
+          },
+          "original_keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Original Keywords",
+            "description": "원본 키워드"
+          },
+          "suggestions": {
+            "items": {
+              "$ref": "#/components/schemas/KeywordSuggestion"
+            },
+            "type": "array",
+            "title": "Suggestions",
+            "description": "제안된 키워드"
+          },
+          "total_suggestions": {
+            "type": "integer",
+            "title": "Total Suggestions",
+            "description": "총 제안 수"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "original_keywords",
+          "suggestions",
+          "total_suggestions"
+        ],
+        "title": "KeywordSuggestionsResponse",
+        "description": "키워드 제안 응답"
+      },
+      "PaginationInfo": {
+        "properties": {
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "전체 항목 수"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit",
+            "description": "페이지당 항목 수"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset",
+            "description": "시작 오프셋"
+          },
+          "has_next": {
+            "type": "boolean",
+            "title": "Has Next",
+            "description": "다음 페이지 존재 여부"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total",
+          "limit",
+          "offset",
+          "has_next"
+        ],
+        "title": "PaginationInfo",
+        "description": "페이지네이션 정보"
+      },
+      "PriceRange": {
+        "properties": {
+          "min_price": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Price",
+            "description": "최소 가격"
+          },
+          "max_price": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Price",
+            "description": "최대 가격"
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency",
+            "description": "통화 (KRW, USD, EUR 등)"
+          }
+        },
+        "type": "object",
+        "title": "PriceRange",
+        "description": "가격 범위 모델"
+      },
+      "RelevanceLevel": {
+        "type": "string",
+        "enum": [
+          "all",
+          "low",
+          "medium",
+          "high",
+          "very_high"
+        ],
+        "title": "RelevanceLevel",
+        "description": "관련성 레벨"
+      },
+      "ScheduleRequest": {
+        "properties": {
+          "site_name": {
+            "type": "string",
+            "title": "Site Name",
+            "description": "사이트명 (G2B 또는 SAM.gov)"
+          },
+          "cron_expression": {
+            "type": "string",
+            "title": "Cron Expression",
+            "description": "크론 표현식 (분 시 일 월 요일)",
+            "example": "0 9 * * *"
+          },
+          "job_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Job Id",
+            "description": "작업 ID (미지정시 자동 생성)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "site_name",
+          "cron_expression"
+        ],
+        "title": "ScheduleRequest",
+        "description": "스케줄 추가 요청 모델"
+      },
+      "ScheduleResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "요청 성공 여부"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "응답 메시지"
+          },
+          "site_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Site Name",
+            "description": "사이트명"
+          },
+          "cron_expression": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cron Expression",
+            "description": "크론 표현식"
+          },
+          "job_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Job Id",
+            "description": "작업 ID"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message"
+        ],
+        "title": "ScheduleResponse",
+        "description": "스케줄 관리 응답 모델"
+      },
+      "ScheduledJob": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "작업 ID"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "작업 이름"
+          },
+          "next_run": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Run",
+            "description": "다음 실행 시간 ISO 포맷"
+          },
+          "trigger": {
+            "type": "string",
+            "title": "Trigger",
+            "description": "트리거 설정"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "trigger"
+        ],
+        "title": "ScheduledJob",
+        "description": "예약된 작업 모델"
+      },
+      "ScheduledJobsResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "요청 성공 여부"
+          },
+          "scheduled_jobs": {
+            "items": {
+              "$ref": "#/components/schemas/ScheduledJob"
+            },
+            "type": "array",
+            "title": "Scheduled Jobs",
+            "description": "예약된 작업 목록"
+          },
+          "scheduler_running": {
+            "type": "boolean",
+            "title": "Scheduler Running",
+            "description": "스케줄러 실행 상태"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "scheduled_jobs",
+          "scheduler_running"
+        ],
+        "title": "ScheduledJobsResponse",
+        "description": "예약된 작업 조회 응답"
+      },
+      "SearchFilter": {
+        "properties": {
+          "field": {
+            "type": "string",
+            "title": "Field",
+            "description": "필터링할 필드명"
+          },
+          "operator": {
+            "type": "string",
+            "title": "Operator",
+            "description": "연산자 (eq, ne, gt, lt, gte, lte, in, not_in, contains, starts_with, ends_with)"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "items": {},
+                "type": "array"
+              }
+            ],
+            "title": "Value",
+            "description": "필터 값"
+          }
+        },
+        "type": "object",
+        "required": [
+          "field",
+          "operator",
+          "value"
+        ],
+        "title": "SearchFilter",
+        "description": "검색 필터"
+      },
+      "SearchOperator": {
+        "type": "string",
+        "enum": [
+          "and",
+          "or",
+          "not"
+        ],
+        "title": "SearchOperator",
+        "description": "검색 연산자"
+      },
+      "SearchResult": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id",
+            "description": "ID"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title",
+            "description": "제목"
+          },
+          "organization": {
+            "type": "string",
+            "title": "Organization",
+            "description": "발주기관"
+          },
+          "source_site": {
+            "type": "string",
+            "title": "Source Site",
+            "description": "출처 사이트"
+          },
+          "source_url": {
+            "type": "string",
+            "title": "Source Url",
+            "description": "원문 URL"
+          },
+          "country": {
+            "type": "string",
+            "title": "Country",
+            "description": "국가"
+          },
+          "announcement_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Announcement Date",
+            "description": "공고일"
+          },
+          "deadline_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deadline Date",
+            "description": "마감일"
+          },
+          "estimated_price": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Estimated Price",
+            "description": "추정 가격"
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency",
+            "description": "통화"
+          },
+          "relevance_score": {
+            "type": "number",
+            "title": "Relevance Score",
+            "description": "관련성 점수"
+          },
+          "urgency_level": {
+            "type": "string",
+            "title": "Urgency Level",
+            "description": "긴급도"
+          },
+          "matched_keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Matched Keywords",
+            "description": "매칭된 키워드",
+            "default": []
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata",
+            "description": "메타데이터"
+          },
+          "relevance_explanation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Relevance Explanation",
+            "description": "관련성 점수 설명"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "organization",
+          "source_site",
+          "source_url",
+          "country",
+          "relevance_score",
+          "urgency_level"
+        ],
+        "title": "SearchResult",
+        "description": "검색 결과 항목"
+      },
+      "SiteComplianceDetails": {
+        "properties": {
+          "slug": {
+            "type": "string",
+            "title": "Slug",
+            "description": "Unique identifier for the site entry"
+          },
+          "country": {
+            "type": "string",
+            "title": "Country",
+            "description": "Country name or code for the site"
+          },
+          "site_name": {
+            "type": "string",
+            "title": "Site Name",
+            "description": "Official name of the procurement platform"
+          },
+          "base_urls": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Base Urls",
+            "description": "Relevant base URLs for the platform"
+          },
+          "robots_txt_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Robots Txt Url",
+            "description": "Direct URL to the robots.txt file if known"
+          },
+          "robots_notes": {
+            "type": "string",
+            "title": "Robots Notes",
+            "description": "Summary of the robots.txt availability or findings"
+          },
+          "crawling_constraints": {
+            "type": "string",
+            "title": "Crawling Constraints",
+            "description": "Practical considerations or limitations when crawling the site"
+          },
+          "legal_notes": {
+            "type": "string",
+            "title": "Legal Notes",
+            "description": "Copyright or legal reuse considerations for collected materials"
+          },
+          "last_reviewed": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Last Reviewed",
+            "description": "Timestamp when the information was last reviewed"
+          }
+        },
+        "type": "object",
+        "required": [
+          "slug",
+          "country",
+          "site_name",
+          "base_urls",
+          "robots_notes",
+          "crawling_constraints",
+          "legal_notes"
+        ],
+        "title": "SiteComplianceDetails",
+        "description": "Represents compliance and crawling guidance for a procurement site."
+      },
+      "SiteComplianceListResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "Indicates whether the request succeeded"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "Number of entries returned"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SiteComplianceDetails"
+            },
+            "type": "array",
+            "title": "Data",
+            "description": "Collection of site compliance entries"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "total",
+          "data"
+        ],
+        "title": "SiteComplianceListResponse",
+        "description": "Response model containing a collection of site compliance entries."
+      },
+      "SiteComplianceResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "Indicates whether the request succeeded"
+          },
+          "data": {
+            "$ref": "#/components/schemas/SiteComplianceDetails",
+            "description": "Compliance entry for the requested site"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "data"
+        ],
+        "title": "SiteComplianceResponse",
+        "description": "Response model returning a single site compliance entry."
+      },
+      "SiteCrawlerResultResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "요청 성공 여부"
+          },
+          "site": {
+            "type": "string",
+            "title": "Site",
+            "description": "사이트명"
+          },
+          "result": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Result",
+            "description": "크롤링 결과"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "site",
+          "result"
+        ],
+        "title": "SiteCrawlerResultResponse",
+        "description": "사이트별 크롤링 결과 응답"
+      },
+      "UrgencyLevel": {
+        "type": "string",
+        "enum": [
+          "low",
+          "medium",
+          "high",
+          "urgent"
+        ],
+        "title": "UrgencyLevel",
+        "description": "긴급도 레벨"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- export the FastAPI OpenAPI schema and store it under docs/seegene_bid_mcp_openapi.json for Copilot Studio
- document the /bids query parameters with descriptions and data types so Copilot Studio can surface limit, offset, site, country, and min_relevance filters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d28181900483289d962fdf51280f9a